### PR TITLE
feature/calculateTab - Transition to loading state

### DIFF
--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -5,7 +5,8 @@ import {
   TabStyled,
   TabContentContainerStyled,
   IconStyled,
-  LabelStyled
+  LabelStyled,
+  LoadingMessage,
 } from "./styles/Styled";
 
 async function calculateTabToShow(tab) {
@@ -27,17 +28,26 @@ class Tabs extends Component {
   constructor(props) {
     super(props);
     this.state = {
+      loading: false,
       selectedTab: props.selectedTab || 0
     };
   }
 
   handleClick = async (tab, index) => {
-    this.setState({ selectedTab: await calculateTabToShow(index) });
+    this.setState({
+      loading: true,
+    });
+    const selectedTab = await calculateTabToShow(index);
+    this.setState({
+      loading: false,
+      selectedTab,
+    });
     this.props.onTabSelected && this.props.onTabSelected(tab);
   };
 
   render() {
     const { layout, size } = this.props;
+    const { loading } = this.state;
     const TabContent = () => layout[this.state.selectedTab].tabContent;
     return (
       <TabsContainerStyled>
@@ -52,7 +62,8 @@ class Tabs extends Component {
             />
           ))}
         </TabListStyled>
-        <TabContentContainerStyled>
+        {loading && <LoadingMessage>Loading...</LoadingMessage>}
+        <TabContentContainerStyled loading={loading}>
           <TabContent />
         </TabContentContainerStyled>
       </TabsContainerStyled>

--- a/src/components/Tabs/styles/Styled.js
+++ b/src/components/Tabs/styles/Styled.js
@@ -67,4 +67,12 @@ export const TabContentContainerStyled = styled.div`
   color:  ${props => props.theme.components.tabs.color};
   text-align: ${props => props.theme.components.tabs.align || "center"};
   padding: ${props => props.theme.components.tabs.padding};
+  transition: transform 0.3s ease-out;
+  transform-origin: top;
+  transform: scaleY(${props => props.loading ? 0 : 1});
+`;
+
+export const LoadingMessage = styled.div`
+  color: ${props => props.theme.color.white};
+  text-align: center;
 `;


### PR DESCRIPTION
If the `calculateTab` function has to run every time the tab is clicked and we need the result of the function to show the next tab we can't do too many improvements here but improve the UX and display a loading message.