### PR TITLE
feature/calculateTab - Move calculateTab to after change the tab

### DIFF
--- a/src/components/Tabs/Tabs.js
+++ b/src/components/Tabs/Tabs.js
@@ -32,8 +32,11 @@ class Tabs extends Component {
   }
 
   handleClick = async (tab, index) => {
-    this.setState({ selectedTab: await calculateTabToShow(index) });
+    this.setState({
+      selectedTab: index,
+    });
     this.props.onTabSelected && this.props.onTabSelected(tab);
+    await calculateTabToShow(index);
   };
 
   render() {


### PR DESCRIPTION
If the result of the `calculateTab` method is not needed to display the tab, ie: if the function just registers clicks, we can postpone the execution of the function and display the tab first.